### PR TITLE
Missing Indentation

### DIFF
--- a/AirSimE2EDeepLearning/TestModel.ipynb
+++ b/AirSimE2EDeepLearning/TestModel.ipynb
@@ -51,7 +51,7 @@
     "    best_model = max(models, key=os.path.getctime)\n",
     "    MODEL_PATH = best_model\n",
     "    \n",
-    "print('Using model {0} for testing.'.format(best_model))"
+    "    print('Using model {0} for testing.'.format(best_model))"
    ]
   },
   {


### PR DESCRIPTION
If a proper `MODEL_PATH` is defined this print statement will cause an error since `best_model` won't be defined in that case.