### PR TITLE
Update README.md

### DIFF
--- a/AirSimE2EDeepLearning/README.md
+++ b/AirSimE2EDeepLearning/README.md
@@ -43,7 +43,7 @@ You should also be comfortable with Python. At the very least, you should be abl
 1. [Install Anaconda](https://conda.io/docs/user-guide/install/index.html) with Python 3.5 or higher.
 2. [Install CNTK](https://docs.microsoft.com/en-us/cognitive-toolkit/Setup-CNTK-on-your-machine) or [install Tensorflow](https://www.tensorflow.org/install/install_windows)
 3. [Install h5py](http://docs.h5py.org/en/latest/build.html)
-4. [Install Keras](https://keras.io/#installation) and [configure the Keras backend](https://keras.io/backend/) to work with TensorFlow (default) or CNTK.
+4. [Install Keras 2.1.2](https://keras.io/#installation) and [configure the Keras backend](https://keras.io/backend/) to work with TensorFlow (default) or CNTK. ([Related Issue](https://github.com/Microsoft/AutonomousDrivingCookbook/issues/1))
 5. [Install AzCopy](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy). Be sure to add the location for the AzCopy executable to your system path.
 6. Install the other dependencies. From your anaconda environment, run "InstallPackages.py" as root or administrator. This installs the following packages into your environment:
     * jupyter


### PR DESCRIPTION
Add Keras version requirement == 2.1.2 for AirSimE2EDeepLearning. 
Related issue https://github.com/Microsoft/AutonomousDrivingCookbook/issues/1